### PR TITLE
Fix rounding issue on the buy order's fill

### DIFF
--- a/test/singleMatchingTests.js
+++ b/test/singleMatchingTests.js
@@ -1,6 +1,7 @@
 /* eslint-disable mocha/no-async-describe */
 
 const _ = require('lodash');
+const BigNumber = require('bignumber.js');
 const { orderBookMatcherBothTypes } = require('./testHelpers/orderBookMatcher');
 const testHelperBuilder = require('./testHelpers/testHelper');
 
@@ -169,7 +170,7 @@ describe('Dex: Single matching tests', function() {
     },
     {
       description:
-        'single match, sell order filled, sell.price < matchPrice < buy.price. The correct lockingAmount is substracted from the sell order',
+        'single match, buy order filled, sell.price < matchPrice < buy.price. The correct lockingAmount is substracted from the sell order',
       buyOrders: {
         description: 'GIVEN there is a buy order',
         orders: [{ lockingAmount: 100, price: 20 }]
@@ -308,6 +309,155 @@ describe('Dex: Single matching tests', function() {
         description: 'AND the buy orderbook still has an order',
         orders: [{ id: 1, lockedAmount: 10, price: 1 }]
       }
+    },
+    {
+      description: 'single match, buy orders filled, small price difference',
+      config: {
+        commissionRate: 0 // no commission
+      },
+      accounts: {
+        1: {
+          baseBalance: 200000,
+          baseAllowance: 200000,
+          secondaryBalance: 200000,
+          secondaryAllowance: 200000
+        },
+        2: {
+          baseBalance: 200000,
+          baseAllowance: 200000,
+          secondaryBalance: 200000,
+          secondaryAllowance: 200000
+        }
+      },
+      buyOrders: {
+        description: 'GIVEN there is a buy order',
+        orders: [{ lockingAmount: 200, price: 2.02, accountIndex: 1, commission: 0 }]
+      },
+      sellOrders: {
+        description: 'AND a sell order at the same price',
+        orders: [{ lockingAmount: 1000, price: 1.98, accountIndex: 2, commission: 0 }]
+      },
+      buyerMatches: {
+        description: 'THEN the buyer is filled',
+        matches: [
+          {
+            orderId: 1,
+            amountSent: new BigNumber('198.019801980198019800'),
+            change: new BigNumber('200').minus('198.019801980198019800'),
+            received: new BigNumber('99.009900990099009900'),
+            commission: 0,
+            matchPrice: 2,
+            filled: true
+          }
+        ]
+      },
+      sellerMatches: {
+        description: 'AND the seller has still amount left',
+        matches: [
+          {
+            orderId: 2,
+            amountSent: new BigNumber('99.009900990099009900'),
+            commission: 0,
+            received: new BigNumber('198.019801980198019800'),
+            surplus: new BigNumber('1.980198019801980198'),
+            remainingAmount: new BigNumber('1000').minus('99.009900990099009900'),
+            matchPrice: 2
+          }
+        ]
+      },
+      remainingSellOrders: {
+        description: 'AND the sell orderbook still has an order',
+        orders: [
+          {
+            id: 2,
+            lockedAmount: new BigNumber('1000').minus('99.009900990099009900'),
+            price: 1.98
+          }
+        ]
+      },
+      remainingBuyOrders: {
+        description: 'AND the buy orderbook is empty',
+        orders: []
+      },
+      expectedAccounts: [{ balance: 20, allowance: 20 }, { balance: 20, allowance: 20 }]
+    },
+    {
+      description: 'single match, sell orders filled, small price difference',
+      config: {
+        commissionRate: 0 // no commission
+      },
+      accounts: {
+        1: {
+          baseBalance: 200000,
+          baseAllowance: 200000,
+          secondaryBalance: 200000,
+          secondaryAllowance: 200000
+        },
+        2: {
+          baseBalance: 200000,
+          baseAllowance: 200000,
+          secondaryBalance: 200000,
+          secondaryAllowance: 200000
+        }
+      },
+      buyOrders: {
+        description: 'GIVEN there is a buy order',
+        orders: [{ lockingAmount: 2000, price: 2.02, accountIndex: 1, commission: 0 }]
+      },
+      sellOrders: {
+        description: 'AND a sell order at the same price with an amount with a very high precision',
+        orders: [
+          {
+            lockingAmount: new BigNumber('100.001001001001001001'),
+            price: 1.98,
+            accountIndex: 2,
+            commission: 0
+          }
+        ]
+      },
+      buyerMatches: {
+        description: 'THEN the buyer has still amount left',
+        matches: [
+          {
+            orderId: 1,
+            amountSent: new BigNumber('200.002002002002002002'),
+            change: new BigNumber('202.002022022022022022').minus('200.002002002002002002'),
+            received: new BigNumber('100.001001001001001001'),
+            remainingAmount: new BigNumber('2000').minus('202.002022022022022022'),
+            commission: 0,
+            matchPrice: 2
+          }
+        ]
+      },
+      sellerMatches: {
+        description: 'AND the seller is filled',
+        matches: [
+          {
+            orderId: 2,
+            amountSent: new BigNumber('100.001001001001001001'),
+            commission: 0,
+            received: new BigNumber('200.002002002002002002'),
+            surplus: new BigNumber('200.002002002002002002').minus('198.001981981981981981'),
+            matchPrice: 2,
+            filled: true
+          }
+        ]
+      },
+      remainingSellOrders: {
+        description: 'AND the sell orderbook still has an order',
+        orders: []
+      },
+      remainingBuyOrders: {
+        description: 'AND the buy orderbook is empty',
+        orders: [
+          {
+            id: 1,
+            lockedAmount: new BigNumber('2000').minus('202.002022022022022022'),
+            price: 2.02
+          }
+        ]
+      },
+      expectedAccounts: [{ balance: 20, allowance: 20 }, { balance: 20, allowance: 20 }]
     }
   ].forEach(matcher);
 });

--- a/test/testHelpers/assertsHelper.js
+++ b/test/testHelpers/assertsHelper.js
@@ -72,7 +72,7 @@ const convertFieldsIntoContractPrecision = (wadify, pricefy) => ({
     orderId: orderId.toString()
   };
   if (matchPrice) Object.assign(withPrecision, { matchPrice: pricefy(matchPrice) });
-  if (filled) Object.assign(withPrecision, { remainingAmount: pricefy(0) });
+  if (filled) Object.assign(withPrecision, { remainingAmount: wadify(0) });
 
   return args
     ? Object.keys(args).reduce(

--- a/test/testHelpers/orderBookMatcher.js
+++ b/test/testHelpers/orderBookMatcher.js
@@ -125,7 +125,7 @@ const insertBuyMarketOrder = (
 const expectInsertionEventMarket = isBuy => (
   receipt,
   { baseTokenAddress, secondaryTokenAddress, price, commission, lockingAmount }
-) => {
+) =>
   expectEvent.inTransaction(receipt.tx, MoCDecentralizedExchange, 'NewOrderInserted', {
     baseTokenAddress,
     secondaryTokenAddress,
@@ -134,8 +134,6 @@ const expectInsertionEventMarket = isBuy => (
     price: pricefy(price / MARKET_PRICE), // This field is actually the priceMultiplier
     isBuy
   });
-};
-
 const expectInsertionEventLimit = isBuy => (
   receipt,
   { baseTokenAddress, secondaryTokenAddress, price, commission, lockingAmount }


### PR DESCRIPTION
# What? 

- Fix rounding issue
This issue arises when the buy order is being filled, in that case the
limiting amount multiplied by the order's price can be slightly less
than the actual amount left in the order because of the multiplication
following the division to calculate the limiting amount. This leaves some dust in the
order. To avoid this issue, when the buy order is filled just sent
everything left. This does not happen in the sell order because the
limiting amount is exactly the amount in the order